### PR TITLE
sm8250-common: parts: Improve HBM

### DIFF
--- a/parts/src/org/lineageos/settings/hbm/AutoHBMService.java
+++ b/parts/src/org/lineageos/settings/hbm/AutoHBMService.java
@@ -3,6 +3,7 @@ package org.lineageos.settings.hbm;
 import android.app.KeyguardManager;
 import android.app.Service;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -15,6 +16,7 @@ import android.os.IBinder;
 import android.os.PowerManager;
 import androidx.preference.PreferenceManager;
 import android.provider.Settings;
+import android.util.Log;
 
 import org.lineageos.settings.utils.FileUtils;
 import java.util.concurrent.ExecutorService;
@@ -22,19 +24,30 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class AutoHBMService extends Service {
+    private static final String ACTION_SCREEN_ON = "android.intent.action.SCREEN_ON";
+    private static final String ACTION_SCREEN_OFF = "android.intent.action.SCREEN_OFF";
     private static final String HBM = "/sys/class/drm/card0/card0-DSI-1/disp_param";
     private static final String BACKLIGHT = "/sys/class/backlight/panel0-backlight/brightness";
-
-    private static boolean mAutoHBMActive = false;
+    private float lux;
+    private float threshold;
+    private float lower_threshold =;
     private ExecutorService mExecutorService;
+    private static final String TAG = "AutoHBM";
+    private static final int MAX_BACKLIGHT = 2047;
+    private static final int DEFAULT_SCREEN_BRIGHTNESS = 255;
+    private static final int MIN_SCREEN_BRIGHTNESS_THRESHOLD = 230;
 
     private SensorManager mSensorManager;
     Sensor mLightSensor;
+    private int currentBrightness;
 
     private SharedPreferences mSharedPrefs;
 
     public void activateLightSensorRead() {
+        threshold = Float.parseFloat(mSharedPrefs.getString(HBMFragment.KEY_AUTO_HBM_THRESHOLD, "6000"));
+        lower_threshold = (threshold >= 6000) ? (threshold - 2000) : 3000;
         submit(() -> {
+            ContentResolver contentResolver = getContentResolver();
             mSensorManager = (SensorManager) getApplicationContext().getSystemService(Context.SENSOR_SERVICE);
             mLightSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_LIGHT);
             mSensorManager.registerListener(mSensorEventListener, mLightSensor, SensorManager.SENSOR_DELAY_NORMAL);
@@ -44,55 +57,64 @@ public class AutoHBMService extends Service {
     public void deactivateLightSensorRead() {
         submit(() -> {
             mSensorManager.unregisterListener(mSensorEventListener);
-            mAutoHBMActive = false;
-            enableHBM(false);
+            FileUtils.writeLine(HBM, "0xF0000");
         });
     }
 
     private void enableHBM(boolean enable) {
         if (enable) {
             FileUtils.writeLine(HBM, "0x10000");
-            FileUtils.writeLine(BACKLIGHT, "2047");
-            Settings.System.putInt(getContentResolver(), Settings.System.SCREEN_BRIGHTNESS, 255);
+            Settings.System.putInt(getContentResolver(), Settings.System.SCREEN_BRIGHTNESS, String.valueOf(DEFAULT_SCREEN_BRIGHTNESS));
         } else {
             FileUtils.writeLine(HBM, "0xF0000");
-            FileUtils.writeLine(BACKLIGHT, "2047");
+            FileUtils.writeLine(BACKLIGHT, String.valueOf(MAX_BACKLIGHT));
         }
-
     }
+
     private boolean isCurrentlyEnabled() {
         return FileUtils.getFileValueAsBoolean(HBM, false);
     }
 
-    private static final int DELAY_MILLIS = 7000; // 7 seconds
+    private void writeBacklight(float currentAmbient) {
+        final float BASE_BACKLIGHT = 1f;
+        final float BACKLIGHT_INCREMENT = MAX_BACKLIGHT/(10000f-lower_threshold);
+        float backlightOffset = 0f;
+        if(isCurrentlyEnabled()) {
+            backlightOffset = (currentAmbient-lower_threshold)*BACKLIGHT_INCREMENT;
+            int intBacklight = (int) BASE_BACKLIGHT + backlightOffset;
+            intBacklight = (intBacklight > MAX_BACKLIGHT) ? MAX_BACKLIGHT : intBacklight;
+            Log.i(TAG,"Set HBM brightness of "+(intBacklight)+" nits at "+lux+" lux");
+        }
+    }
 
     private SensorEventListener mSensorEventListener = new SensorEventListener() {
         @Override
         public void onSensorChanged(SensorEvent event) {
-            float lux = event.values[0];
+            lux = event.values[0];
             KeyguardManager km =
                 (KeyguardManager) getSystemService(getApplicationContext().KEYGUARD_SERVICE);
             boolean keyguardShowing = km.inKeyguardRestrictedInputMode();
-            float threshold = Float.parseFloat(mSharedPrefs.getString(HBMFragment.KEY_AUTO_HBM_THRESHOLD, "20000"));
-            if (lux > threshold) {
-                if ((!mAutoHBMActive | !isCurrentlyEnabled()) && !keyguardShowing) {
-                    mAutoHBMActive = true;
+            ContentResolver contentResolver = getContentResolver();
+            try {
+                currentBrightness = Settings.System.getInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS);
+            } catch (Settings.SettingNotFoundException e) {
+                currentBrightness = DEFAULT_SCREEN_BRIGHTNESS;
+                Log.d(TAG,"System does not support changing screen brightness");
+                return;
+            }
+            float threshold = Float.parseFloat(mSharedPrefs.getString(HBMFragment.KEY_AUTO_HBM_THRESHOLD, "6000"));
+            if (lux > threshold && currentBrightness>=MIN_SCREEN_BRIGHTNESS_THRESHOLD && !isCurrentlyEnabled()) {
+                if (!keyguardShowing) {
                     enableHBM(true);
                 }
-            }
-            if (lux < threshold) {
-                if (mAutoHBMActive) {
-                    mAutoHBMActive = false;
-                    mExecutorService.submit(() -> {
-                        try {
-                            Thread.sleep(DELAY_MILLIS);
-                        } catch (InterruptedException e) {
-                        }
-                        if (lux < threshold) {
-                            enableHBM(false);
-                        }
-                    });
-                }
+            } else if (lux < threshold | (currentBrightness<=MIN_SCREEN_BRIGHTNESS_THRESHOLD && isCurrentlyEnabled())) {
+                mExecutorService.submit(() -> {
+                    if (lux < threshold) {
+                        enableHBM(false);
+                    }
+                });
+            } else {
+                writeBacklight(lux);
             }
         }
 
@@ -105,10 +127,12 @@ public class AutoHBMService extends Service {
     private BroadcastReceiver mScreenStateReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (intent.getAction().equals(Intent.ACTION_SCREEN_ON)) {
-                activateLightSensorRead();
-            } else if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
-                deactivateLightSensorRead();
+            if (intent.getAction() != null) {
+                if (intent.getAction().equals(ACTION_SCREEN_ON)) {
+                    activateLightSensorRead();
+                } else if (intent.getAction().equals(ACTION_SCREEN_OFF)) {
+                    deactivateLightSensorRead();
+                }
             }
         }
     };
@@ -121,8 +145,14 @@ public class AutoHBMService extends Service {
         registerReceiver(mScreenStateReceiver, screenStateFilter);
         mSharedPrefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
-        if (pm.isInteractive()) {
-            activateLightSensorRead();
+        if (pm != null) {
+            try {
+                if (pm.isInteractive()) {
+                    activateLightSensorRead();
+                }
+            } catch (SecurityException e) {
+                Log.e(TAG, "Permission denied to check interactive state", e);
+            }
         }
     }
 
@@ -139,10 +169,7 @@ public class AutoHBMService extends Service {
     public void onDestroy() {
         super.onDestroy();
         unregisterReceiver(mScreenStateReceiver);
-        PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
-        if (pm.isInteractive()) {
-            deactivateLightSensorRead();
-        }
+        deactivateLightSensorRead();
     }
 
     @Override

--- a/parts/src/org/lineageos/settings/hbm/AutoHBMThresholdPreference.java
+++ b/parts/src/org/lineageos/settings/hbm/AutoHBMThresholdPreference.java
@@ -26,9 +26,9 @@ import androidx.preference.PreferenceViewHolder;
 
 public class AutoHBMThresholdPreference extends CustomSeekBarPreference {
 
-    private static int mMinVal = 0;
-    private static int mMaxVal = 60000;
-    private static int mDefVal = 20000;
+    private static int mMinVal = 3000;
+    private static int mMaxVal = 10000;
+    private static int mDefVal = 6000;
 
     public AutoHBMThresholdPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -42,7 +42,7 @@ public class AutoHBMThresholdPreference extends CustomSeekBarPreference {
         mDefaultValueExists = true;
         mDefaultValue = mDefVal;
         SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(getContext());
-        mValue = Integer.parseInt(sharedPrefs.getString(HBMFragment.KEY_AUTO_HBM_THRESHOLD, "20000"));
+        mValue = Integer.parseInt(sharedPrefs.getString(HBMFragment.KEY_AUTO_HBM_THRESHOLD, "6000"));
 
         setPersistent(false);
     }


### PR DESCRIPTION
Fix issue where AOD brightness would be overidden to panel maximum if autohbm was enabled

Made autohbm use trigger values between 3000lux to 10000lux (anything out of this range doesn't really make sense)

Disable hbm at 3000lux or (threshold - 2000)lux as long as the threshold is more than 6000lux (avoids disabling of hbm when theres a sudden drop in ambient brightness)

Scale hbm brightness with ambient light level

Improve code readability and handle exceptions better

Get rid of redundant variables